### PR TITLE
Feat post like

### DIFF
--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -8,7 +8,6 @@ import Board from 'components/Community/Board/Board';
 import Header from 'components/UI/Header';
 import Tab from 'components/UI/Tab';
 import api from 'lib/api';
-import { communityDetailType } from 'types/community';
 
 type TabType = {
   name: string;
@@ -123,7 +122,7 @@ const Page: NextPage = () => {
         ))}
       </TabList>
       <BoardList>
-        {data?.map((item: communityDetailType, index: number) => (
+        {data?.map((item: any, index: number) => (
           <Board data={item} key={index} onClick={handleDetailPage} />
         ))}
       </BoardList>

--- a/pages/createBoard/index.tsx
+++ b/pages/createBoard/index.tsx
@@ -190,7 +190,7 @@ const Page: NextPage = () => {
             alt="back"
             width={21}
             height={20}
-            onClick={() => router.push('/community')}
+            onClick={() => router.back()}
           />
 
           <HeaderTitle>게시글 수정</HeaderTitle>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,7 +5,13 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe ui', Roboto, Oxygen,
     Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
-
+::-webkit-scrollbar {
+  width: 5px;
+  background-color: #e9e9e9;
+}
+::-webkit-scrollbar-thumb {
+  background-color: #c5c2c2;
+}
 a {
   color: inherit;
   text-decoration: none;

--- a/types/community.ts
+++ b/types/community.ts
@@ -3,6 +3,7 @@ export interface communityDetailType {
   content: string;
   createDate: string;
   id: number;
+  postId?: number;
   likeCount: number;
   myLike: boolean;
   myPost: boolean;


### PR DESCRIPTION
### 게시글 상세페이지 좋아요 기능 구현

커뮤니티 상세 페이지 좋아요 누를시 데이터 refetch 해서 좋아요 숫자 & 좋아요 누른 여부 반영해서 나타나게 했지만
조회수 가 올라가는 이슈 발생,

같은 유저가 조회시 조회수가 올라가지 않게 구현 필요 